### PR TITLE
rinna のテンプレート修正

### DIFF
--- a/packages/cdk/lambda/utils/sagemakerApi.ts
+++ b/packages/cdk/lambda/utils/sagemakerApi.ts
@@ -21,10 +21,12 @@ const invoke = async (
   messages: UnrecordedMessage[],
   params: PredictParams = {}
 ): Promise<string> => {
+  let _input = generatePrompt(messages);
+  console.log(`Input prompt: ${_input}`)
   const command = new InvokeEndpointCommand({
     EndpointName: process.env.MODEL_NAME,
     Body: JSON.stringify({
-      inputs: generatePrompt(messages),
+      inputs: _input,
       parameters: { ...PARAMS, ...params },
     }),
     ContentType: 'application/json',
@@ -38,10 +40,12 @@ async function* invokeStream(
   messages: UnrecordedMessage[],
   params: PredictParams = {}
 ): AsyncIterable<string> {
+  let _input = generatePrompt(messages);
+  console.log(`Input prompt: ${_input}`)
   const command = new InvokeEndpointWithResponseStreamCommand({
     EndpointName: process.env.MODEL_NAME,
     Body: JSON.stringify({
-      inputs: generatePrompt(messages),
+      inputs: _input,
       parameters: { ...PARAMS, ...params },
       stream: true,
     }),

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -6,4 +6,7 @@ import svgr from 'vite-plugin-svgr';
 export default defineConfig({
   resolve: { alias: { './runtimeConfig': './runtimeConfig.browser' } },
   plugins: [react(), svgr()],
+  server: {
+    port : 8080
+  }
 });

--- a/prompt-templates/bilingualRinna.json
+++ b/prompt-templates/bilingualRinna.json
@@ -1,6 +1,6 @@
 {
     "prefix": "",
-    "suffix": "",
+    "suffix": "\nシステム: ",
     "join": "\n",
     "user": "ユーザー: {}",
     "assistant": "システム: {}",

--- a/prompt-templates/rinna.json
+++ b/prompt-templates/rinna.json
@@ -1,6 +1,6 @@
 {
     "prefix": "",
-    "suffix": "",
+    "suffix": "<NL>システム: ",
     "join": "<NL>",
     "user": "ユーザー: {}",
     "assistant": "システム: {}",


### PR DESCRIPTION
#13 のバグを修正。

rinna 3.6 については "<NL>システム: "、 bilingul については "\nシステム: " を suffix として指定。
改行の扱いがモデルによって異なるためそれぞれに応じて修正。

https://huggingface.co/rinna/japanese-gpt-neox-3.6b-instruction-ppo
https://huggingface.co/rinna/bilingual-gpt-neox-4b-instruction-ppo

## 修正結果

修正後の動作確認結果

ユーザーの発話が「。」などで終了しても空白の応答が帰ってこないことを確認。

![image](https://github.com/llm-jp/llm-jp-model-playground/assets/544269/90b28d93-1703-4c74-9964-0a35b488ffee)

`PredictStream` の Lambda Function に promp を出力させて、モデルが意図する通り "システム: "でプロンプトが切れることを確認。

```
2023-10-29T06:25:07.355Z	47a90d3c-c317-4be6-958c-44bbbe1b2ef0	INFO	Input prompt: システム: あなたはチャットでユーザを支援するAIアシスタントです。
ユーザー: こんにちは
システム: 
```
